### PR TITLE
[(fixclienthandle204_systematic)] Fixed handling 204 response which h…

### DIFF
--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -377,6 +377,10 @@ public abstract class BaseClient implements IRestfulClient {
 					}
 				}
 
+				if (inputStreamToReturn == null) {
+					inputStreamToReturn = new ByteArrayInputStream(new byte[]{});
+				}
+
 				return binding.invokeClient(mimeType, inputStreamToReturn, response.getStatus(), headers);
 			}
 

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2Test.java
@@ -14,6 +14,8 @@ import ca.uhn.fhir.model.dstu2.resource.Bundle.Entry;
 import ca.uhn.fhir.model.dstu2.resource.Bundle.Link;
 import ca.uhn.fhir.model.dstu2.resource.Conformance.Rest;
 import ca.uhn.fhir.model.dstu2.resource.Conformance.RestSecurity;
+import ca.uhn.fhir.model.dstu2.valueset.BundleTypeEnum;
+import ca.uhn.fhir.model.dstu2.valueset.HTTPVerbEnum;
 import ca.uhn.fhir.model.primitive.*;
 import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.parser.IParser;
@@ -22,6 +24,7 @@ import ca.uhn.fhir.rest.api.*;
 import ca.uhn.fhir.rest.client.apache.ApacheRestfulClientFactory;
 import ca.uhn.fhir.rest.client.api.*;
 import ca.uhn.fhir.rest.client.exceptions.InvalidResponseException;
+import ca.uhn.fhir.rest.client.exceptions.NonFhirResponseException;
 import ca.uhn.fhir.rest.client.impl.BaseClient;
 import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import ca.uhn.fhir.rest.param.DateParam;
@@ -2358,6 +2361,33 @@ public class GenericClientDstu2Test {
 
 		assertEquals("Patient/1/_history/1", response.getEntry().get(0).getResponse().getLocation());
 		assertEquals("Patient/2/_history/2", response.getEntry().get(1).getResponse().getLocation());
+	}
+
+	@Test
+	public void testTransactionHandle204NoBody() throws Exception {
+
+		IGenericClient client = ourCtx.newRestfulGenericClient("http://example.com/fhir");
+
+		ca.uhn.fhir.model.dstu2.resource.Bundle bundle = new Bundle();
+		bundle.setType(BundleTypeEnum.TRANSACTION);
+
+		ca.uhn.fhir.model.dstu2.resource.Bundle.Entry entry = bundle.addEntry();
+		entry.setResource(new Patient());
+		entry.getRequest().setMethod(HTTPVerbEnum.PUT);
+
+
+
+		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
+		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
+		when(myHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), Constants.STATUS_HTTP_204_NO_CONTENT, ""));
+		when(myHttpResponse.getEntity() ).thenReturn(null);
+
+		try {
+			client.transaction().withBundle(bundle).execute();
+			fail("Should throw an exception");
+		} catch (NonFhirResponseException e) {
+			assertEquals("status", Constants.STATUS_HTTP_204_NO_CONTENT, e.getStatusCode());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
The hapi client cannot handle a 204 response. An HTTP 204 response has no body and the client fails with the stacktrace:
java.lang.NullPointerException
at java.io.Reader.(Reader.java:78)
at java.io.InputStreamReader.(InputStreamReader.java:113)
at ca.uhn.fhir.rest.client.exceptions.NonFhirResponseException.newInstance(NonFhirResponseException.java:51)
at ca.uhn.fhir.rest.client.impl.BaseClient$ResourceResponseHandler.invokeClient(BaseClient.java:572)
at ca.uhn.fhir.rest.client.impl.BaseClient$ResourceResponseHandler.invokeClient(BaseClient.java:531)
at ca.uhn.fhir.rest.client.impl.BaseClient.invokeClient(BaseClient.java:381)
at ca.uhn.fhir.rest.client.impl.GenericClient$BaseClientExecutable.invoke(GenericClient.java:434)
at ca.uhn.fhir.rest.client.impl.GenericClient$TransactionExecutable.execute(GenericClient.java:2015)

Fix: Replace null inputStreamToReturn with an empty input stream.